### PR TITLE
flutter_svg dependency version bump to ^0.18.0

### DIFF
--- a/adobe_xd/example/pubspec.lock
+++ b/adobe_xd/example/pubspec.lock
@@ -22,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   charcode:
     dependency: transitive
     description:
@@ -169,7 +176,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.16"
   typed_data:
     dependency: transitive
     description:
@@ -192,5 +199,5 @@ packages:
     source: hosted
     version: "3.6.1"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.9.0-14.0.dev <3.0.0"
   flutter: ">=1.6.7 <2.0.0"

--- a/adobe_xd/pubspec.lock
+++ b/adobe_xd/pubspec.lock
@@ -15,6 +15,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   charcode:
     dependency: transitive
     description:
@@ -61,7 +68,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.4"
+    version: "0.18.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -108,7 +115,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -155,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.16"
   typed_data:
     dependency: transitive
     description:
@@ -176,7 +183,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.1"
+    version: "4.2.0"
 sdks:
-  dart: ">=2.6.0 <3.0.0"
-  flutter: ">=1.6.7 <2.0.0"
+  dart: ">=2.9.0-14.0.dev <3.0.0"
+  flutter: ">=1.18.0-6.0.pre <2.0.0"

--- a/adobe_xd/pubspec.yaml
+++ b/adobe_xd/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: 'flutter'
-  flutter_svg: ^0.17.0
+  flutter_svg: ^0.18.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I bumped the version of flutter_svg to the latest one in the pubspec.yaml and pubspec.lock.

Until this PR gets merged, please add this to your project's pubspec.yaml:
```yaml
dependency_overrides:
  # For adobe_xd with Flutter 1.20.0
  flutter_svg: ^0.18.0
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

flutter/flutter#58635

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Due to a breaking change made by flutter/flutter#58635 with flutter 1.20.0 (channel dev at the time of writing), we have to upgrade flutter_svg to 0.18.0 or else it won't run.
See https://stackoverflow.com/questions/62481800/flutter-run-failed-to-build-ios-app-command-phasescriptexecution-failed-with

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Since there are no Unit tests, it has been tested on my personal project using:
```yaml
  adobe_xd:
    path: xd-to-flutter-plugin/adobe_xd/
```
The SVG files are still loading.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.