### PR TITLE
fix small typo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://flutter.dev/docs/get-started/codelab
 
 
 ## Hot Reload
-Hot reload will alow you to see changes you make reflected on a device or simulator immediately each time you export from XD.
+Hot reload will allow you to see changes you make reflected on a device or simulator immediately each time you export from XD.
 
 To enable it, open the settings for the Dart extension in VS Code, and turn on `Preview Hot Reload On Save Watcher`. This will automatically hot reload your Flutter app whenever an external application (such as Adobe XD) saves changes to a `.dart` file in your project.
 


### PR DESCRIPTION
## Description

fix small typo readme `alow` to `allow`

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
